### PR TITLE
Bump versions of Spine modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 buildscript {
     standardSpineSdkRepositories()
 
-    apply(from = "$rootDir/version.gradle.kts")
     val spine = io.spine.internal.dependency.Spine(rootProject)
     dependencies {
         classpath(spine.mcJavaPlugin)
@@ -75,7 +74,6 @@ spinePublishing {
         // We only publish one module because it produces a fat JAR publication.
         "model-check"
     )
-
     destinations = with(PublishingRepos) {
         setOf(
             cloudRepo,
@@ -83,7 +81,6 @@ spinePublishing {
             cloudArtifactRegistry
         )
     }
-
     dokkaJar {
         enabled = true
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 buildscript {
     standardSpineSdkRepositories()
 
-    val spine = io.spine.internal.dependency.Spine(rootProject)
     dependencies {
-        classpath(spine.mcJavaPlugin)
+        classpath(io.spine.internal.dependency.Spine.McJava.pluginLib)
     }
 
     io.spine.internal.gradle.doForceVersions(configurations)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -171,7 +171,7 @@ subprojects {
                     "io.grpc:protoc-gen-grpc-java:${Grpc.version}",
 
                     spine.base,
-                    spine.validate,
+                    spine.validation.runtime,
                     spine.testlib,
 
                     Grpc.core,

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.21.6"
+    const val version       = "3.19.6"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.121`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.122`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -45,16 +45,16 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.9.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.46.0.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
@@ -84,6 +84,7 @@
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.61.**No license information found**
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.5.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
@@ -249,20 +250,20 @@
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.9.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.20.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -441,9 +442,10 @@
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.protodata. **Name** : protodata-fat-cli. **Version** : 0.2.12.**No license information found**
-1.  **Group** : io.spine.protodata. **Name** : protodata-protoc. **Version** : 0.2.12.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-extensions. **Version** : 2.0.0-SNAPSHOT.27.**No license information found**
+1.  **Group** : io.spine.protodata. **Name** : protodata-fat-cli. **Version** : 0.3.0.**No license information found**
+1.  **Group** : io.spine.protodata. **Name** : protodata-protoc. **Version** : 0.3.0.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.61.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.61.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -461,7 +463,7 @@
      * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
-1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 2.0.2.**No license information found**
+1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.0.1.**No license information found**
 1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 11.4.
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
@@ -751,12 +753,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 16 16:16:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 17 15:41:44 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-check:2.0.0-SNAPSHOT.121`
+# Dependencies of `io.spine.tools:spine-model-check:2.0.0-SNAPSHOT.122`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -809,16 +811,16 @@ This report was generated on **Wed Nov 16 16:16:33 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.9.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.squareup. **Name** : javapoet. **Version** : 1.13.0.
      * **Project URL:** [http://github.com/square/javapoet/](http://github.com/square/javapoet/)
@@ -856,6 +858,7 @@ This report was generated on **Wed Nov 16 16:16:33 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.61.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -1029,20 +1032,20 @@ This report was generated on **Wed Nov 16 16:16:33 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.21.9.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.21.9.
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.6.
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.20.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.6.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
-     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -1221,9 +1224,10 @@ This report was generated on **Wed Nov 16 16:16:33 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.spine.protodata. **Name** : protodata-fat-cli. **Version** : 0.2.12.**No license information found**
-1.  **Group** : io.spine.protodata. **Name** : protodata-protoc. **Version** : 0.2.12.**No license information found**
-1.  **Group** : io.spine.validation. **Name** : spine-validation-java-extensions. **Version** : 2.0.0-SNAPSHOT.27.**No license information found**
+1.  **Group** : io.spine.protodata. **Name** : protodata-fat-cli. **Version** : 0.3.0.**No license information found**
+1.  **Group** : io.spine.protodata. **Name** : protodata-protoc. **Version** : 0.3.0.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-bundle. **Version** : 2.0.0-SNAPSHOT.61.**No license information found**
+1.  **Group** : io.spine.validation. **Name** : spine-validation-java-runtime. **Version** : 2.0.0-SNAPSHOT.61.**No license information found**
 1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
      * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
@@ -1241,7 +1245,7 @@ This report was generated on **Wed Nov 16 16:16:33 EET 2022** using [Gradle-Lice
      * **License:** [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [LGPL, version 2.1](http://www.gnu.org/licenses/licenses.html)
 
-1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 2.0.2.**No license information found**
+1.  **Group** : net.ltgt.gradle. **Name** : gradle-errorprone-plugin. **Version** : 3.0.1.**No license information found**
 1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 11.4.
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
@@ -1531,4 +1535,4 @@ This report was generated on **Wed Nov 16 16:16:33 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 16 16:16:35 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 17 15:41:45 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model-assembler/build.gradle.kts
+++ b/model-assembler/build.gradle.kts
@@ -33,6 +33,6 @@ plugins {
 dependencies {
     val spine = Spine(project)
     implementation(spine.server)
-    implementation(spine.validate)
+    implementation(spine.validation.runtime)
     testImplementation(spine.testlib)
 }

--- a/model-assembler/src/main/java/io/spine/model/assemble/AssignLookup.java
+++ b/model-assembler/src/main/java/io/spine/model/assemble/AssignLookup.java
@@ -141,7 +141,7 @@ public class AssignLookup extends ModelAnnotationProcessor {
     private void writeAssigneesTo(File file) {
         ensureFile(file);
         removeDuplicates();
-        var serializedModel = commandAssignees.vBuild();
+        var serializedModel = commandAssignees.build();
         if (!isDefault(serializedModel)) {
             try (var out = new FileOutputStream(file)) {
                 serializedModel.writeTo(out);

--- a/model-assembler/src/main/java/io/spine/model/assemble/AssignLookup.java
+++ b/model-assembler/src/main/java/io/spine/model/assemble/AssignLookup.java
@@ -50,7 +50,7 @@ import static io.spine.protobuf.Messages.isDefault;
 /**
  * An annotation processor for the {@link Assign @Assign} annotation.
  *
- * <p>Collects the types which contain methods {@linkplain Assign assigned} to handle commands
+ * <p>Collects the types, which contain methods {@linkplain Assign assigned} to handle commands
  * and writes them into the {@code ${spineDirRoot}/.spine/spine_model.ser} file,
  * where "{@code spineDirRoot}" is the value of the <b>spineDirRoot</b> annotator option.
  *
@@ -67,13 +67,13 @@ public class AssignLookup extends ModelAnnotationProcessor {
     private static final String DEFAULT_OUTPUT_OPTION = ".";
 
     /**
-     * List of {@linkplain io.spine.server.command.CommandAssignee command assignee}s.
+     * List of {@linkplain io.spine.server.command.Assignee assignee}s.
      *
-     * @implNote The type of this filed implies that it can store {@code CommandReceiver}s,
-     *           which could be either {@code CommandAssignee} or {@code Commander}. But we are
+     * @implNote The type of this field implies that it can store {@code CommandReceiver}s,
+     *           which could be either {@code Assignee} or {@code Commander}. But we are
      *           going to store only assignees there.
      */
-    private final CommandReceivers.Builder commandAssignees = CommandReceivers.newBuilder();
+    private final CommandReceivers.Builder assignees = CommandReceivers.newBuilder();
 
     @Override
     protected Class<? extends Annotation> getAnnotationType() {
@@ -94,7 +94,7 @@ public class AssignLookup extends ModelAnnotationProcessor {
         var enclosingTypeElement = (TypeElement) element.getEnclosingElement();
         var typeName = enclosingTypeElement.getQualifiedName()
                                            .toString();
-        commandAssignees.addCommandReceivingType(typeName);
+        assignees.addCommandReceivingType(typeName);
     }
 
     @Override
@@ -107,41 +107,41 @@ public class AssignLookup extends ModelAnnotationProcessor {
     }
 
     /**
-     * Merges the currently built {@link AssignLookup#commandAssignees} with the pre-built one.
+     * Merges the currently built {@link AssignLookup#assignees} with the pre-built one.
      *
      * <p>If the file exists and is not empty, the message of type {@link CommandReceivers} is
-     * read from it and merged with the current commandAssignees by the rules of
+     * read from it and merged with the current {@code assignees} by the rules of
      * {@link com.google.protobuf.Message.Builder#mergeFrom(com.google.protobuf.Message)
      * Message.Builder.mergeFrom()}.
      *
      * @param file
-     *         the file which may or may not contain the pre-assembled commandAssignees
+     *         the file, which may or may not contain the pre-assembled {@code assignees}
      */
     @SuppressWarnings("CheckReturnValue") // calling builder
     private void mergeOldAssigneesFrom(File file) {
         var fileWithData = existsNonEmpty(file);
         if (fileWithData) {
             var preexistingModel = readExisting(file);
-            commandAssignees.mergeFrom(preexistingModel);
+            assignees.mergeFrom(preexistingModel);
         }
     }
 
     /**
-     * Writes the {@link AssignLookup#commandAssignees} to the given file.
+     * Writes the {@link AssignLookup#assignees} to the given file.
      *
      * <p>If the given file does not exist, this method creates it.
      *
-     * <p>The written commandAssignees will be cleaned from duplications in the repeated fields.
+     * <p>The written {@code assignees} will be cleaned from duplications in the repeated fields.
      *
      * <p>The I/O errors are handled by rethrowing them as {@link IllegalStateException}.
      *
      * @param file
-     *         an existing file to write the commandAssignees into
+     *         an existing file to write the {@code assignees} into
      */
     private void writeAssigneesTo(File file) {
         ensureFile(file);
         removeDuplicates();
-        var serializedModel = commandAssignees.build();
+        var serializedModel = assignees.build();
         if (!isDefault(serializedModel)) {
             try (var out = new FileOutputStream(file)) {
                 serializedModel.writeTo(out);
@@ -152,21 +152,21 @@ public class AssignLookup extends ModelAnnotationProcessor {
     }
 
     /**
-     * Cleans the currently built {@link #commandAssignees} from the duplicates.
+     * Cleans the currently built {@link AssignLookup#assignees} from the duplicates.
      *
      * <p>Calling this method will cause the current list of assignees not to contain
      * duplicate entries in any {@code repeated} field.
      */
     @SuppressWarnings("CheckReturnValue") // calling builder
     private void removeDuplicates() {
-        var list = commandAssignees.getCommandReceivingTypeList();
+        var list = assignees.getCommandReceivingTypeList();
         Set<String> types = newTreeSet(list);
-        commandAssignees.clearCommandReceivingType()
-                        .addAllCommandReceivingType(types);
+        assignees.clearCommandReceivingType()
+                 .addAllCommandReceivingType(types);
     }
 
     /**
-     * Reads the existing {@link #commandAssignees} from the given file.
+     * Reads the existing {@link AssignLookup#assignees} from the given file.
      *
      * <p>The given file should exist.
      *
@@ -176,7 +176,7 @@ public class AssignLookup extends ModelAnnotationProcessor {
      *
      * @param file
      *         an existing file with a {@link CommandReceivers} message
-     * @return the read commandAssignees
+     * @return the read {@code assignees}
      */
     private static CommandReceivers readExisting(File file) {
         if (file.length() == 0) {

--- a/model-assembler/src/main/java/io/spine/model/assemble/ModelAnnotationProcessor.java
+++ b/model-assembler/src/main/java/io/spine/model/assemble/ModelAnnotationProcessor.java
@@ -50,8 +50,8 @@ import static javax.tools.Diagnostic.Kind.WARNING;
  * An abstract base for the Spine
  * {@linkplain javax.annotation.processing.Processor annotation processors}.
  *
- * <p>This class provides the handy lifecycle for the processors basing on their round-oriented
- * nature.
+ * <p>This class provides the handy lifecycle for the processors basing on their
+ * round-oriented nature.
  *
  * <p>Be sure to add the fully qualified name of your implementation of this class to
  * {@code resources/META_INF/services/javax.annotation.processing.Processor} to make it visible

--- a/model-assembler/src/main/proto/spine/model/spine_model.proto
+++ b/model-assembler/src/main/proto/spine/model/spine_model.proto
@@ -44,8 +44,8 @@ message CommandReceivers {
     //
     // Each type is represented by its Java fully-qualified class name.
     //
-    // These types include `CommandAssignee`s and `Commander`s. Typically, it would be `Aggregate`s,
-    // `ProcessManager`s, and standalone components implementing `AbstractCommandAssignee`
+    // These types include `Assignee`s and `Commander`s. Typically, it would be `Aggregate`s,
+    // `ProcessManager`s, and standalone components implementing `AbstractAssignee`
     // or `AbstractCommander` directly.
     repeated string command_receiving_type = 1;
 }

--- a/model-assembler/src/test/java/io/spine/model/assemble/ModelAnnotationProcessorTest.java
+++ b/model-assembler/src/test/java/io/spine/model/assemble/ModelAnnotationProcessorTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("`SpineAnnotationProcessor` should")
+@DisplayName("`ModelAnnotationProcessor` should")
 abstract class ModelAnnotationProcessorTest {
 
     private ModelAnnotationProcessor processor;

--- a/model-check/src/main/java/io/spine/model/check/ModelCheck.java
+++ b/model-check/src/main/java/io/spine/model/check/ModelCheck.java
@@ -63,9 +63,10 @@ public class ModelCheck implements Logging {
     private final URLClassLoader projectClassLoader;
 
     /**
-     * Creates a new instance of the {@code ModelVerifier}.
+     * Creates a new instance.
      *
-     * @param project the Gradle project to verify the model upon
+     * @param project
+     *         the Gradle project to verify the model upon
      */
     public ModelCheck(Project project) {
         this.projectClassLoader = createClassLoader(project);
@@ -74,7 +75,8 @@ public class ModelCheck implements Logging {
     /**
      * Verifies Spine model upon the given Gradle project.
      *
-     * @param receivers the listing of the Spine model classes
+     * @param receivers
+     *         the listing of the Spine model classes
      */
     public void verify(CommandReceivers receivers) {
         var classSet = new ClassSet(projectClassLoader,

--- a/model-check/src/main/java/io/spine/model/check/plugin/ModelCheckPlugin.java
+++ b/model-check/src/main/java/io/spine/model/check/plugin/ModelCheckPlugin.java
@@ -93,7 +93,7 @@ public final class ModelCheckPlugin implements Plugin<Project>, Logging {
     /**
      * The action performing the model processing.
      *
-     * <p>The action is executed only if the passed {@code rawModelPath} is present.
+     * <p>It is executed only if the passed {@code rawModelPath} is present.
      *
      * <p>Reads the {@link CommandReceivers} from the given file and
      * {@linkplain #verifyModel processes} the model.

--- a/model-check/src/test/java/io/spine/model/check/ModelCheckTest.java
+++ b/model-check/src/test/java/io/spine/model/check/ModelCheckTest.java
@@ -36,8 +36,8 @@ import io.spine.model.check.given.InvalidEnhanceAggregate;
 import io.spine.model.check.given.InvalidRestoreAggregate;
 import io.spine.model.check.given.RenameProcMan;
 import io.spine.model.check.given.UploadCommandAssignee;
-import io.spine.server.command.model.CommandAssigneeSignature;
-import io.spine.server.model.DuplicateCommandHandlerError;
+import io.spine.server.command.model.AssigneeSignature;
+import io.spine.server.model.DuplicateCommandReceptorError;
 import io.spine.server.model.ExternalCommandReceiverMethodError;
 import io.spine.server.model.SignatureMismatchException;
 import io.spine.testing.TempDir;
@@ -125,7 +125,7 @@ class ModelCheckTest {
                 .addCommandReceivingType(firstType)
                 .addCommandReceivingType(secondType)
                 .build();
-        assertThrows(DuplicateCommandHandlerError.class, () -> verifier.verify(spineModel));
+        assertThrows(DuplicateCommandReceptorError.class, () -> verifier.verify(spineModel));
     }
 
     @Test
@@ -146,7 +146,7 @@ class ModelCheckTest {
         private final Class<?> aggregateClass = InvalidRestoreAggregate.class;
 
         WarnLogging() {
-            super(CommandAssigneeSignature.class, Level.WARNING);
+            super(AssigneeSignature.class, Level.WARNING);
         }
 
         @BeforeEach

--- a/model-check/src/test/java/io/spine/model/check/given/DuplicateCommandAssignee.java
+++ b/model-check/src/test/java/io/spine/model/check/given/DuplicateCommandAssignee.java
@@ -28,10 +28,10 @@ package io.spine.model.check.given;
 
 import io.spine.model.check.given.command.UploadPhoto;
 import io.spine.model.check.given.event.PhotoUploaded;
-import io.spine.server.command.AbstractCommandAssignee;
+import io.spine.server.command.AbstractAssignee;
 import io.spine.server.command.Assign;
 
-public class DuplicateCommandAssignee extends AbstractCommandAssignee {
+public class DuplicateCommandAssignee extends AbstractAssignee {
 
     @Assign
     PhotoUploaded handle(UploadPhoto command) {

--- a/model-check/src/test/java/io/spine/model/check/given/UploadCommandAssignee.java
+++ b/model-check/src/test/java/io/spine/model/check/given/UploadCommandAssignee.java
@@ -28,10 +28,10 @@ package io.spine.model.check.given;
 
 import io.spine.model.check.given.command.UploadPhoto;
 import io.spine.model.check.given.event.PhotoUploaded;
-import io.spine.server.command.AbstractCommandAssignee;
+import io.spine.server.command.AbstractAssignee;
 import io.spine.server.command.Assign;
 
-public class UploadCommandAssignee extends AbstractCommandAssignee {
+public class UploadCommandAssignee extends AbstractAssignee {
 
     @Assign
     PhotoUploaded handle(UploadPhoto command) {

--- a/model-check/src/test/resources/model-check-test/build.gradle.kts
+++ b/model-check/src/test/resources/model-check-test/build.gradle.kts
@@ -41,10 +41,9 @@ buildscript {
 
     standardSpineSdkRepositories()
 
-    val spine = io.spine.internal.dependency.Spine(rootProject)
     dependencies {
         classpath(io.spine.internal.dependency.Protobuf.GradlePlugin.lib)
-        classpath(spine.mcJavaPlugin)
+        classpath(io.spine.internal.dependency.Spine.McJava.pluginLib)
         classpath("io.spine.tools:spine-model-check-bundle:${versionToPublish}")
     }
 

--- a/model-check/src/test/resources/model-check-test/src/main/java/io/spine/model/check/test/ValidCommandAssignee.java
+++ b/model-check/src/test/resources/model-check-test/src/main/java/io/spine/model/check/test/ValidCommandAssignee.java
@@ -27,7 +27,7 @@
 package io.spine.model.check.test;
 
 import io.spine.base.EventMessage;
-import io.spine.server.command.AbstractCommandAssignee;
+import io.spine.server.command.AbstractAssignee;
 import io.spine.server.command.Assign;
 
 import java.util.List;
@@ -38,9 +38,9 @@ import io.spine.model.check.test.command.*;
 import io.spine.model.check.test.event.*;
 
 /**
- * A {@code CommandAssignee} with a valid command-handling method.
+ * An {@code Assignee} with a valid command-handling method.
  */
-public class ValidCommandAssignee extends AbstractCommandAssignee {
+public class ValidCommandAssignee extends AbstractAssignee {
 
     @Assign
     List<? extends EventMessage> handle(SendLink command) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-model-tools</artifactId>
-<version>2.0.0-SNAPSHOT.121</version>
+<version>2.0.0-SNAPSHOT.122</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -26,25 +26,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.107</version>
+    <version>2.0.0-SNAPSHOT.120</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.108</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
-    <groupId>io.spine</groupId>
-    <artifactId>spine-validate</artifactId>
-    <version>2.0.0-SNAPSHOT.107</version>
+    <version>2.0.0-SNAPSHOT.119</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.95</version>
+    <version>2.0.0-SNAPSHOT.121</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.validation</groupId>
+    <artifactId>spine-validation-java-runtime</artifactId>
+    <version>2.0.0-SNAPSHOT.61</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -56,19 +56,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.95</version>
+    <version>2.0.0-SNAPSHOT.121</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.107</version>
+    <version>2.0.0-SNAPSHOT.120</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-server</artifactId>
-    <version>2.0.0-SNAPSHOT.108</version>
+    <version>2.0.0-SNAPSHOT.119</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -90,7 +90,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.20.1</version>
+    <version>3.19.6</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>
@@ -110,12 +110,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-fat-cli</artifactId>
-    <version>0.2.12</version>
+    <version>0.3.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.protodata</groupId>
     <artifactId>protodata-protoc</artifactId>
-    <version>0.2.12</version>
+    <version>0.3.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -125,18 +125,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.99</version>
+    <version>2.0.0-SNAPSHOT.106</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.99</version>
+    <version>2.0.0-SNAPSHOT.106</version>
   </dependency>
   <dependency>
     <groupId>io.spine.validation</groupId>
-    <artifactId>spine-validation-java-extensions</artifactId>
-    <version>2.0.0-SNAPSHOT.27</version>
+    <artifactId>spine-validation-java-bundle</artifactId>
+    <version>2.0.0-SNAPSHOT.61</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.121")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.122")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,13 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** Versions of the Spine libraries that `model-tools-java` depends on. */
-val baseVersion: String by extra("2.0.0-SNAPSHOT.107")
-val baseTypesVersion: String by extra("2.0.0-SNAPSHOT.97")
-val timeVersion: String by extra("2.0.0-SNAPSHOT.96")
-val coreVersion: String by extra("2.0.0-SNAPSHOT.108")
-val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.95")
-val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.99")
-
-/** The version of this library. */
+/**
+ * The version of this library.
+ *
+ * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
+ */
 val versionToPublish: String by extra("2.0.0-SNAPSHOT.121")


### PR DESCRIPTION
This PR drops manual declaration of versions for the used Spine modules. Now, this module uses versions declared in `Spine` dependency object. 

The code has been adjusted to the latest changes in `core-java`.

Protobuf is downgraded to `config`'s version (`3.19.6`). In the previous [PR](https://github.com/SpineEventEngine/model-tools/pull/7), I've firstly bumped it to `2.21.9`, then restored back to a lower version `3.21.6`. But it seems, It was needed to downgrade it down to `config` version.

The library version is bumped to `2.0.0-SNAPSHOT.122`.